### PR TITLE
[Redis] Perform Type Casts On Floats

### DIFF
--- a/tilecache/TileCache/Caches/Redis.py
+++ b/tilecache/TileCache/Caches/Redis.py
@@ -55,7 +55,7 @@ class Redis(Cache):
         key = self.getKey(tile)
         pipeline = self.cache.pipeline()
         pipeline.hmset(key, {'data': data, 'last_updated': time.time()})
-        pipeline.expire(key, self.expiration)
+        pipeline.expire(key, int(self.expiration))
         pipeline.execute()
         return data
 
@@ -102,7 +102,7 @@ class Redis(Cache):
         if result:
             self.cache.expire(
                 self.getLockName(tile),
-                self.timeout + 1
+                int(self.timeout + 1)
             )
 
         return result


### PR DESCRIPTION
This fixes a type-error I found happens if the default floating point values are used. The underlying redis library expects integers and so will raise a TypeError. We now simply cast these values to integers to ensure they are always of the correct type.
