### PR TITLE
Fix sphinx-build 'unbalanced parenthesis' error.

### DIFF
--- a/tilecache/docs/Example.py.txt
+++ b/tilecache/docs/Example.py.txt
@@ -16,23 +16,12 @@ myService = Service (
   Disk("/www/wms-c/cache"), 
   { 
     "basic"     : MS.MapServer( "basic", "/www/wms-c/basic.map" ),
-    "satellite" : MS.MapServer( "satellite", "/www/wms-c/basic.map",
-                                extension = "jpeg" ),
-    "cascade"   : WMS.WMS( "basic", "http://labs.metacarta.com/wms/vmap0?",
-                                extension = "jpeg" ),
-    "DRG"       : WMS.WMS( "DRG", "http://terraservice.net/ogcmap.ashx?",
-                                extension = "jpeg"  ),
-    "OSM"       : WMS.WMS( "roads", 
-                    "http://aesis.metacarta.com/cgi-bin/mapserv?FORMAT=png8&" +
-                    "map=/home/crschmidt/osm.map&TRANSPARENT=TRUE&",
-                    extension = "png"  ),
-    "Boston"    : WMS.WMS( 
-                    "border,water,openspace,roads,buildings,rapid_transit",
-                    "http://nyc.freemap.in/cgi-bin/mapserv?" + 
-                    "map=/www/freemap.in/boston/map/gmaps.map&" ),
-    "hfoot"     : WMS.WMS( "hfoot", 
-                    "http://beta.sedac.ciesin.columbia.edu/mapserver/wms/hfoot?",
-                    levels = 20, extension = "jpeg")
+    "satellite" : MS.MapServer( "satellite", "/www/wms-c/basic.map", extension = "jpeg" ),
+    "cascade"   : WMS.WMS( "basic", "http://labs.metacarta.com/wms/vmap0?", extension = "jpeg" ),
+    "DRG"       : WMS.WMS( "DRG", "http://terraservice.net/ogcmap.ashx?", extension = "jpeg" ),
+    "OSM"       : WMS.WMS( "roads", "http://aesis.metacarta.com/cgi-bin/mapserv?FORMAT=png8&map=/home/crschmidt/osm.map&TRANSPARENT=TRUE&", extension = "png" ),
+    "Boston"    : WMS.WMS( "border,water,openspace,roads,buildings,rapid_transit", "http://nyc.freemap.in/cgi-bin/mapserv?map=/www/freemap.in/boston/map/gmaps.map&" ),
+    "hfoot"     : WMS.WMS( "hfoot", "http://beta.sedac.ciesin.columbia.edu/mapserver/wms/hfoot?", levels = 20, extension = "jpeg" )
   }
 ) 
 


### PR DESCRIPTION
As reported in [Debian Bug #811262](https://bugs.debian.org/811262), tilecache failed to build with sphinx 1.3.4:

```
  sphinx-build docs/ docs/html/
  Running Sphinx v1.3.4
  making output directory...
  loading pickled environment... not yet created
  building [mo]: targets for 0 po files that are out of date
  building [html]: targets for 9 source files that are out of date
  updating environment: 9 added, 0 changed, 0 removed
  reading sources... [ 11%] CONTRIBUTORS
  reading sources... [ 22%] Caches
  reading sources... [ 33%] EXAMPLES
  reading sources... [ 44%] Example.py

  Exception occurred:
    File "/usr/lib/python2.7/re.py", line 251, in _compile
      raise error, v # invalid expression
  error: unbalanced parenthesis
```

Fixed by using single lines for the properties.
