### PR TITLE
Bypass "too far from file corner" error.

### DIFF
--- a/tilecache/TileCache/Layer.py
+++ b/tilecache/TileCache/Layer.py
@@ -510,8 +510,8 @@ class Layer (object):
         x0 = (minx - self.bbox[0]) / (res * self.size[0])
         y0 = (miny - self.bbox[1]) / (res * self.size[1])
         
-        x = round(x0)
-        y = round(y0)
+        x = int(round(x0))
+        y = int(round(y0))
         
         tilex = ((x * res * self.size[0]) + self.bbox[0])
         tiley = ((y * res * self.size[1]) + self.bbox[1])

--- a/tilecache/TileCache/Layer.py
+++ b/tilecache/TileCache/Layer.py
@@ -478,7 +478,7 @@ class Layer (object):
     ##        (3, 1, 2)
     ############################################################################
     
-    def getCell (self, (minx, miny, maxx, maxy), exact = True):
+    def getCell (self, (minx, miny, maxx, maxy), exact = False):
         """
         Returns x, y, z
 


### PR DESCRIPTION
It simply sets the default behavior to bypass the following errors:

* "Lower left corner (MINX, MINY) is outside layer bounds BBOX. To remove this condition, set extent_type=loose in your configuration."
* "Current x value MINX is too far from tile corner x TILEX"
* "Current y value MINY is too far from tile corner y TILEY"

This is a workaround for Issue #1 